### PR TITLE
Implemented dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A high-performance uptime monitoring system built with Bun and ClickHouse. Recei
 - **Hierarchical Groups** - Organize monitors with flexible health strategies (any-up, all-up, percentage)
 - **Custom Metrics** - Track up to 3 numeric values per monitor (player count, connections, etc.)
 - **Multi-Channel Notifications** - Discord, Email, Ntfy and Telegram support with per-monitor control
+- **Dependency-Based Notification Suppression** - Define dependencies between monitors/groups to avoid notification storms when infrastructure fails
 - **Real-Time Status Pages** - WebSocket-powered live updates
 - **Self-Healing** - Automatic backfill when the monitor itself recovers from downtime
 
@@ -84,6 +85,7 @@ curl http://localhost:3000/v1/status/:slug
 | [API Reference](docs/api.md)                                           | All endpoints and WebSocket events          |
 | [Notifications](docs/notifications.md)                                 | Setting up Discord, Email, Ntfy, Telegram   |
 | [Groups & Strategies](docs/groups.md)                                  | Organizing monitors hierarchically          |
+| [Dependencies](docs/dependencies.md)                                   | Notification suppression via dependencies   |
 | [Custom Metrics](docs/custom-metrics.md)                               | Tracking additional data points             |
 | [PulseMonitor Integration](docs/pulsemonitor.md)                       | Automated monitoring from multiple regions  |
 | [Visual Configuration Editor](https://uptime-monitor.org/configurator) | Web-based UI for configuring monitors       |

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "nodemailer": "^8.0.1",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.8",
+        "@types/bun": "^1.3.9",
         "@types/nodemailer": "^7.0.9",
       },
       "peerDependencies": {
@@ -32,13 +32,13 @@
 
     "@rabbit-company/web-middleware": ["@rabbit-company/web-middleware@0.18.1", "", { "dependencies": { "@rabbit-company/logger": "^5.6.0", "@rabbit-company/rate-limiter": "^3.0.1" }, "peerDependencies": { "@rabbit-company/web": "^0.18.1" } }, "sha512-DMXH0PDI45/kEkxzTHqd6a9wMwWrqmlnIVBwqwX0VYFuqnsDU5tw7mSxmKPv15rd3vPVd/dM42sRU0xUoYbM5w=="],
 
-    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
 
     "@types/nodemailer": ["@types/nodemailer@7.0.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow=="],
 
-    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "nodemailer": ["nodemailer@8.0.1", "", {}, "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg=="],
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,19 +134,27 @@ resendNotification = 12
 groupId = "production"
 notificationChannels = ["critical"]
 pulseMonitors = ["US-WEST-1"]
+# dependencies = ["server-group"]  # Suppress notifications if dependency is down
 ```
 
-| Field                  | Required | Default | Description                                                  |
-| ---------------------- | -------- | ------- | ------------------------------------------------------------ |
-| `id`                   | Yes      | -       | Unique identifier                                            |
-| `name`                 | Yes      | -       | Display name                                                 |
-| `token`                | Yes      | -       | Secret token for pulse authentication                        |
-| `interval`             | Yes      | -       | Expected pulse interval in seconds (see [Pulses](pulses.md)) |
-| `maxRetries`           | Yes      | -       | Missed pulses before marking down (see [Pulses](pulses.md))  |
-| `resendNotification`   | Yes      | -       | Resend notification every N down checks (0 = never)          |
-| `groupId`              | No       | -       | Parent group ID                                              |
-| `notificationChannels` | No       | `[]`    | Array of notification channel IDs                            |
-| `pulseMonitors`        | No       | `[]`    | Array of PulseMonitor IDs for automated checking             |
+| Field                  | Required | Default | Description                                                                                                                                |
+| ---------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`                   | Yes      | -       | Unique identifier                                                                                                                          |
+| `name`                 | Yes      | -       | Display name                                                                                                                               |
+| `token`                | Yes      | -       | Secret token for pulse authentication                                                                                                      |
+| `interval`             | Yes      | -       | Expected pulse interval in seconds (see [Pulses](pulses.md))                                                                               |
+| `maxRetries`           | Yes      | -       | Missed pulses before marking down (see [Pulses](pulses.md))                                                                                |
+| `resendNotification`   | Yes      | -       | Resend notification every N down checks (0 = never)                                                                                        |
+| `groupId`              | No       | -       | Parent group ID                                                                                                                            |
+| `notificationChannels` | No       | `[]`    | Array of notification channel IDs                                                                                                          |
+| `pulseMonitors`        | No       | `[]`    | Array of PulseMonitor IDs for automated checking                                                                                           |
+| `dependencies`         | No       | `[]`    | Array of monitor/group IDs. If any dependency is down, notifications for this monitor are suppressed (see [Dependencies](dependencies.md)) |
+
+### Dependency-Based Notification Suppression
+
+Monitors and groups can declare dependencies on other monitors or groups using the `dependencies` array.
+When any dependency is down, notifications for the dependent entity are suppressed - preventing
+notification storms when upstream infrastructure fails. See [Dependencies](dependencies.md) for full documentation.
 
 ### Custom Metrics
 
@@ -213,18 +221,20 @@ interval = 60
 resendNotification = 12
 parentId = "all-services"
 notificationChannels = ["critical"]
+# dependencies = ["network"]       # Suppress notifications if dependency is down
 ```
 
-| Field                  | Required | Default | Description                                      |
-| ---------------------- | -------- | ------- | ------------------------------------------------ |
-| `id`                   | Yes      | -       | Unique identifier                                |
-| `name`                 | Yes      | -       | Display name                                     |
-| `strategy`             | Yes      | -       | `"any-up"`, `"all-up"`, or `"percentage"`        |
-| `degradedThreshold`    | Yes      | -       | Percentage threshold (0-100) for degraded status |
-| `interval`             | Yes      | -       | Used for uptime calculations                     |
-| `resendNotification`   | No       | `0`     | Resend notification every N down checks          |
-| `parentId`             | No       | -       | Parent group ID for nesting                      |
-| `notificationChannels` | No       | `[]`    | Array of notification channel IDs                |
+| Field                  | Required | Default | Description                                                                                                                              |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | Yes      | -       | Unique identifier                                                                                                                        |
+| `name`                 | Yes      | -       | Display name                                                                                                                             |
+| `strategy`             | Yes      | -       | `"any-up"`, `"all-up"`, or `"percentage"`                                                                                                |
+| `degradedThreshold`    | Yes      | -       | Percentage threshold (0-100) for degraded status                                                                                         |
+| `interval`             | Yes      | -       | Used for uptime calculations                                                                                                             |
+| `resendNotification`   | No       | `0`     | Resend notification every N down checks                                                                                                  |
+| `parentId`             | No       | -       | Parent group ID for nesting                                                                                                              |
+| `notificationChannels` | No       | `[]`    | Array of notification channel IDs                                                                                                        |
+| `dependencies`         | No       | `[]`    | Array of monitor/group IDs. If any dependency is down, notifications for this group are suppressed (see [Dependencies](dependencies.md)) |
 
 ### Strategy Reference
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,198 @@
+# Dependencies & Notification Suppression
+
+When infrastructure fails, you typically don't want a flood of notifications for every service affected by the same root cause. For example, if a server goes down, you shouldn't get separate alerts for the server _and_ each of the three apps running on it - just one notification for the server is enough.
+
+Dependencies let you define these relationships so that only the **highest-level** entity that is down triggers a notification.
+
+## How It Works
+
+Both monitors and groups support an optional `dependencies` array. This is a list of monitor or group IDs that the entity depends on. When a notification would normally be sent (down, still-down, or recovered), the system first checks whether any of the listed dependencies are currently down. If so, the notification is **suppressed**.
+
+This means:
+
+- **Down notifications** are suppressed if a dependency is already down
+- **Still-down reminders** are suppressed if a dependency is still down
+- **Recovery notifications** are suppressed if the user never saw a down notification (because it was suppressed)
+- **Status tracking is unaffected** - uptime calculations, group health, and status pages all continue to work normally. Only notifications are suppressed.
+
+## Configuration
+
+### Monitor Dependencies
+
+```toml
+[[monitors]]
+id = "app-1"
+name = "App 1"
+token = "token-app-1"
+interval = 30
+maxRetries = 0
+resendNotification = 0
+groupId = "server-1"
+dependencies = ["server-1"]   # Suppress notifications if server-1 is down
+notificationChannels = ["discord"]
+```
+
+### Group Dependencies
+
+```toml
+[[groups]]
+id = "server-1"
+name = "Server 1"
+strategy = "all-up"
+degradedThreshold = 50
+interval = 30
+resendNotification = 0
+dependencies = ["network"]   # Suppress notifications if network group is down
+notificationChannels = ["discord"]
+```
+
+### Field Reference
+
+| Field          | Type       | Default     | Description                                                                                                           |
+| -------------- | ---------- | ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `dependencies` | `string[]` | `[]` (none) | Array of monitor or group IDs. If any listed ID has a status of "down", notifications for this entity are suppressed. |
+
+## Example: Multi-Layer Infrastructure
+
+Consider this infrastructure:
+
+```
+Internet -> Core Network -> Server -> [App1, App2, App3]
+```
+
+Configure it like this:
+
+```toml
+# Internet connectivity monitor
+[[monitors]]
+id = "internet"
+name = "Internet"
+token = "token-internet"
+interval = 30
+maxRetries = 0
+resendNotification = 0
+notificationChannels = ["discord"]
+
+# Core network group depends on internet
+[[groups]]
+id = "network"
+name = "Core Network"
+strategy = "all-up"
+degradedThreshold = 50
+interval = 30
+resendNotification = 0
+dependencies = ["internet"]
+notificationChannels = ["discord"]
+
+# Server group depends on network
+[[groups]]
+id = "server-1"
+name = "Server 1"
+strategy = "all-up"
+degradedThreshold = 50
+interval = 30
+resendNotification = 0
+parentId = "network"
+dependencies = ["network"]
+notificationChannels = ["discord"]
+
+# Apps depend on their server
+[[monitors]]
+id = "app-1"
+name = "App 1"
+token = "token-app-1"
+interval = 30
+maxRetries = 0
+resendNotification = 0
+groupId = "server-1"
+dependencies = ["server-1"]
+notificationChannels = ["discord"]
+
+[[monitors]]
+id = "app-2"
+name = "App 2"
+token = "token-app-2"
+interval = 30
+maxRetries = 0
+resendNotification = 0
+groupId = "server-1"
+dependencies = ["server-1"]
+notificationChannels = ["discord"]
+
+[[monitors]]
+id = "app-3"
+name = "App 3"
+token = "token-app-3"
+interval = 30
+maxRetries = 0
+resendNotification = 0
+groupId = "server-1"
+dependencies = ["server-1"]
+notificationChannels = ["discord"]
+```
+
+### What happens when the server goes down?
+
+1. **Server 1** group goes down → notification is sent (its dependency `network` is still up)
+2. **App 1, App 2, App 3** all go down → notifications are **suppressed** (their dependency `server-1` is down)
+3. You receive **one notification** instead of four
+
+### What happens when the internet goes down?
+
+1. **Internet** monitor goes down → notification is sent (it has no dependencies)
+2. **Core Network** goes down → notification is **suppressed** (its dependency `internet` is down)
+3. **Server 1** goes down → notification is **suppressed** (its dependency `network` is down)
+4. **App 1, App 2, App 3** go down → notifications are **suppressed** (their dependency `server-1` is down)
+5. You receive **one notification** instead of six
+
+### What about recovery?
+
+When everything comes back up, only the Internet monitor sends a recovery notification. The downstream entities were never announced as down, so their recovery notifications are also suppressed.
+
+## Dependencies vs Group Hierarchy
+
+It's important to understand that `dependencies` and the group hierarchy (`groupId` / `parentId`) serve different purposes:
+
+| Concept             | Purpose                                                                               | Config Field                              |
+| ------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------- |
+| **Group hierarchy** | Status aggregation - calculating group health from children, organizing status pages  | `groupId` (monitors), `parentId` (groups) |
+| **Dependencies**    | Notification suppression - preventing alert storms when upstream infrastructure fails | `dependencies` (monitors and groups)      |
+
+These are orthogonal. A monitor might belong to a group for display purposes but depend on a completely different entity for notification suppression. You can use both, either, or neither.
+
+That said, it's common for `dependencies` to mirror the group hierarchy, as in the example above where apps depend on their parent group.
+
+## Multiple Dependencies
+
+A monitor or group can depend on multiple entities:
+
+```toml
+[[monitors]]
+id = "web-app"
+name = "Web App"
+token = "token-web-app"
+interval = 30
+maxRetries = 0
+resendNotification = 0
+dependencies = ["server-1", "database", "cdn"]
+notificationChannels = ["discord"]
+```
+
+If **any** of `server-1`, `database`, or `cdn` is down, notifications for `web-app` are suppressed. All dependencies must be up for notifications to fire normally.
+
+## Validation Rules
+
+The configuration validates dependencies at load time:
+
+- **References must exist**: Every ID in `dependencies` must correspond to an existing monitor or group
+- **No self-dependencies**: A monitor/group cannot list itself in its own `dependencies`
+- **No circular dependencies**: If A depends on B, B cannot depend on A (directly or transitively)
+- **Cross-type references are allowed**: A monitor can depend on a group, and a group can depend on a monitor
+
+Invalid configurations will cause the server to exit with a descriptive error message at startup.
+
+## Edge Cases
+
+- **Startup / grace period**: During the initial grace period after server startup, no notifications are sent anyway, so dependency suppression is not relevant
+- **Unknown status**: If a dependency has no status yet (e.g., it hasn't been checked), it's treated as "not down" - no suppression occurs
+- **Hot reload**: Dependencies are re-validated when configuration is hot-reloaded via the `/v1/reload/:token` endpoint

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -133,6 +133,32 @@ all-services (percentage, 75%)
     └── web-staging (monitor)
 ```
 
+## Dependencies vs Group Hierarchy
+
+The group hierarchy (`parentId`) and `dependencies` serve different purposes:
+
+- **Group hierarchy** (`parentId`) is for **status aggregation** - calculating whether a group is up, down, or degraded based on its children. It also determines how monitors are organized on status pages.
+- **Dependencies** is for **notification suppression** - when a dependency is down, notifications for the dependent entity are suppressed to avoid alert storms.
+
+These are orthogonal. A group can have a `parentId` for status aggregation and completely different `dependencies` for notification suppression. That said, it's common for them to overlap.
+
+```toml
+# This group is a child of "infrastructure" for status purposes,
+# but depends on "network" for notification suppression
+[[groups]]
+id = "server-1"
+name = "Server 1"
+strategy = "all-up"
+degradedThreshold = 50
+interval = 30
+resendNotification = 0
+parentId = "infrastructure"
+dependencies = ["network"]
+notificationChannels = ["discord"]
+```
+
+See [Dependencies](dependencies.md) for full documentation and examples.
+
 ## Assigning Monitors to Groups
 
 Use the `groupId` field on monitors:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -265,6 +265,34 @@ The `resendNotification` field controls "still-down" reminders:
 - "Still down" reminder every 5 × 12 = 60 seconds while down
 - Recovery notification when back up
 
+## Dependency-Based Notification Suppression
+
+You can configure monitors and groups to suppress notifications when an upstream dependency is down. This prevents notification storms when infrastructure fails - for example, if a server goes down, you won't get separate alerts for each app running on it.
+
+Add a `dependencies` array to any monitor or group:
+
+```toml
+[[monitors]]
+id = "app-1"
+name = "App 1"
+token = "token-app-1"
+interval = 30
+maxRetries = 0
+resendNotification = 0
+dependencies = ["server-1"]       # No notifications if server-1 is down
+notificationChannels = ["discord"]
+```
+
+When `server-1` is down:
+
+- Down notifications for `app-1` are suppressed
+- Still-down reminders for `app-1` are suppressed
+- Recovery notifications for `app-1` are suppressed (since the user never saw a down alert)
+
+Status tracking (uptime, group health, status pages) is unaffected - only notifications are suppressed.
+
+See [Dependencies](dependencies.md) for full documentation, multi-layer examples, and validation rules.
+
 ## Multiple Providers per Channel
 
 A channel can have multiple providers enabled simultaneously:

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
 	"name": "uptimemonitor-server",
 	"module": "src/index.ts",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"type": "module",
 	"private": true,
 	"scripts": {
 		"start": "bun src/index.ts"
 	},
 	"devDependencies": {
-		"@types/bun": "^1.3.8",
+		"@types/bun": "^1.3.9",
 		"@types/nodemailer": "^7.0.9"
 	},
 	"peerDependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,6 +207,8 @@ export interface Monitor {
 	resendNotification: number;
 	/** Optional group ID this monitor belongs to */
 	groupId?: string;
+	/** Array of monitor/group IDs this monitor depends on for notification suppression */
+	dependencies?: string[];
 	/** Notification channel IDs to use for this monitor */
 	notificationChannels?: string[];
 	/** Configuration for custom metric 1 */
@@ -244,6 +246,8 @@ export interface Group {
 	parentId?: string;
 	/** Resend "still-down" notification after this many consecutive down checks (0 = never resend) */
 	resendNotification: number;
+	/** Array of monitor/group IDs this group depends on for notification suppression */
+	dependencies?: string[];
 	/** Notification channel IDs to use for this group */
 	notificationChannels?: string[];
 }
@@ -260,6 +264,8 @@ export interface GroupState {
 	downStartTime?: number;
 	/** The down count at which the last notification was sent (for resendNotification) */
 	lastNotificationCount: number;
+	/** Whether the down notification was suppressed due to a dependency being down */
+	notificationSuppressed?: boolean;
 }
 
 /**
@@ -672,6 +678,8 @@ export interface MonitorState {
 	lastNotificationCount: number;
 	/** Timestamp when the monitor first went down (undefined if monitor is up) */
 	downStartTime?: number;
+	/** Whether the down notification was suppressed due to a dependency being down */
+	notificationSuppressed?: boolean;
 }
 
 /**


### PR DESCRIPTION
### What are dependencies?

When infrastructure fails, you typically don't want a flood of notifications for every service affected by the same root cause. For example, if a server goes down, you shouldn't get separate alerts for the server and each of the three apps running on it - just one notification for the server is enough.

Dependencies let you define these relationships so that only the highest-level entity that is down triggers a notification.